### PR TITLE
[PATH] Allow `gcc_jit_type_get_size` to work with pointers

### DIFF
--- a/gcc/jit/libgccjit.cc
+++ b/gcc/jit/libgccjit.cc
@@ -575,8 +575,8 @@ gcc_jit_type_get_size (gcc_jit_type *type)
 {
   RETURN_VAL_IF_FAIL (type, -1, NULL, NULL, "NULL type");
   RETURN_VAL_IF_FAIL
-    (type->is_int () || type->is_float (), -1, NULL, NULL,
-     "only getting the size of integer or floating-point types is supported for now");
+    (type->is_int () || type->is_float () || type->is_pointer (), -1, NULL, NULL,
+     "only getting the size of integer or floating-point or pointer types is supported for now");
   return type->get_size ();
 }
 


### PR DESCRIPTION
Needed for https://github.com/antoyo/rustc_codegen_gcc/pull/11.