### PR TITLE
Debug info demangling workaround

### DIFF
--- a/gcc/dwarf2out.cc
+++ b/gcc/dwarf2out.cc
@@ -3781,8 +3781,6 @@ static bool is_cxx (void);
 static bool is_cxx (const_tree);
 static bool is_fortran (void);
 static bool is_ada (void);
-static bool is_gccjit (void);
-static bool is_gccjit (const_tree);
 static bool remove_AT (dw_die_ref, enum dwarf_attribute);
 static void remove_child_TAG (dw_die_ref, enum dwarf_tag);
 static void add_child_die (dw_die_ref, dw_die_ref);
@@ -5589,27 +5587,6 @@ is_cxx (const_tree decl)
 	return startswith (TRANSLATION_UNIT_LANGUAGE (context), "GNU C++");
     }
   return is_cxx ();
-}
-
-/* Return TRUE if libgccjit frontend is in use.  */
-static inline bool
-is_gccjit (void)
-{
-    return startswith (lang_hooks.name, "libgccjit");
-}
-
-/* Return TRUE if DECL was created by the libgccjit frontend.  */
-
-static inline bool
-is_gccjit (const_tree decl)
-{
-  if (in_lto_p)
-    {
-      const_tree context = get_ultimate_context (decl);
-      if (context && TRANSLATION_UNIT_LANGUAGE (context))
-	return startswith (TRANSLATION_UNIT_LANGUAGE (context), "libgccjit");
-    }
-  return is_gccjit ();
 }
 
 /* Return TRUE if the language is Fortran.  */
@@ -22129,10 +22106,7 @@ add_linkage_name_raw (dw_die_ref die, tree decl)
       asm_name->next = deferred_asm_name;
       deferred_asm_name = asm_name;
     }
-  else if (DECL_ASSEMBLER_NAME (decl) != DECL_NAME (decl)
-           || (TREE_CODE(decl) == FUNCTION_DECL
-               && is_gccjit()
-               && lookup_attribute ("jit_dwarf_short_name", DECL_ATTRIBUTES (decl))))
+  else if (DECL_ASSEMBLER_NAME (decl) != DECL_NAME (decl))
     add_linkage_attr (die, decl);
 }
 

--- a/gcc/dwarf2out.cc
+++ b/gcc/dwarf2out.cc
@@ -22132,7 +22132,7 @@ add_linkage_name_raw (dw_die_ref die, tree decl)
   else if (DECL_ASSEMBLER_NAME (decl) != DECL_NAME (decl)
            || (TREE_CODE(decl) == FUNCTION_DECL
                && is_gccjit()
-               && lookup_attribute ("short_name", DECL_ATTRIBUTES (decl))))
+               && lookup_attribute ("jit_dwarf_short_name", DECL_ATTRIBUTES (decl))))
     add_linkage_attr (die, decl);
 }
 

--- a/gcc/dwarf2out.cc
+++ b/gcc/dwarf2out.cc
@@ -3987,7 +3987,6 @@ static void gen_type_die_with_usage (tree, dw_die_ref, enum debug_info_usage,
 				     bool = false);
 static void splice_child_die (dw_die_ref, dw_die_ref);
 static int file_info_cmp (const void *, const void *);
-static bool find_short_name_attr (tree);
 static dw_loc_list_ref new_loc_list (dw_loc_descr_ref, const char *, var_loc_view,
 				     const char *, var_loc_view, const char *);
 static void output_loc_list (dw_loc_list_ref);
@@ -22131,7 +22130,9 @@ add_linkage_name_raw (dw_die_ref die, tree decl)
       deferred_asm_name = asm_name;
     }
   else if (DECL_ASSEMBLER_NAME (decl) != DECL_NAME (decl)
-           || (TREE_CODE(decl) == FUNCTION_DECL && is_gccjit() && find_short_name_attr(decl)))
+           || (TREE_CODE(decl) == FUNCTION_DECL
+               && is_gccjit()
+               && lookup_attribute ("short_name", DECL_ATTRIBUTES (decl))))
     add_linkage_attr (die, decl);
 }
 
@@ -23535,25 +23536,6 @@ gen_call_site_die (tree decl, dw_die_ref subr_die,
 		     false);
     }
   return die;
-}
-
-/* Check whether the `decl` node has a short_name` attribute
-   */
-static bool
-find_short_name_attr (tree decl)
-{
-  bool found_name_attr = false;
-  tree short_name_id = get_identifier("short_name");
-
-  for(tree attr_li = DECL_ATTRIBUTES(decl);attr_li;attr_li = TREE_CHAIN(attr_li))
-  {
-    if (TREE_PURPOSE(attr_li) == short_name_id)
-    {
-      found_name_attr = true;
-      break;
-    }
-  }
-  return found_name_attr;
 }
 
 /* Generate a DIE to represent a declared function (either file-scope or

--- a/gcc/jit/dummy-frontend.cc
+++ b/gcc/jit/dummy-frontend.cc
@@ -34,6 +34,7 @@ along with GCC; see the file COPYING3.  If not see
 #include "target.h"
 #include "jit-recording.h"
 #include "print-tree.h"
+#include "langhooks.h"
 
 #include <mpfr.h>
 #include <unordered_map>
@@ -195,7 +196,7 @@ static const attribute_spec jit_gnu_attributes[] =
 			      attr_returns_twice_exclusions },
   { "sentinel",		      0, 1, false, true, true, false,
 			      handle_sentinel_attribute, NULL },
-  { "short_name",	      0, 1, false,  false, false, false,
+  { "jit_dwarf_short_name",   1, 1, false,  false, false, false,
 			      NULL, NULL },
   { "target",		      1, -1, true, false, false, false,
 			      handle_target_attribute, attr_target_exclusions },
@@ -1375,6 +1376,21 @@ jit_langhook_getdecls (void)
   return NULL;
 }
 
+const char *
+jit_langhook_dwarf_name (tree decl, int verbosity)
+{
+  tree attr = NULL;
+  const char* name = NULL;
+  if (false
+      || !(decl
+           && FUNCTION_DECL == TREE_CODE(decl)
+           && (attr = lookup_attribute("jit_dwarf_short_name", DECL_ATTRIBUTES(decl)))
+           && (name = TREE_STRING_POINTER (TREE_VALUE (attr)))))
+    return lhd_dwarf_name (decl, verbosity);
+  else
+    return name;
+}
+
 static tree
 jit_langhook_eh_personality (void)
 {
@@ -1417,6 +1433,9 @@ jit_langhook_eh_personality (void)
 
 #undef LANG_HOOKS_GETDECLS
 #define LANG_HOOKS_GETDECLS		jit_langhook_getdecls
+
+#undef LANG_HOOKS_DWARF_NAME
+#define LANG_HOOKS_DWARF_NAME           jit_langhook_dwarf_name
 
 /* Attribute hooks.  */
 #undef LANG_HOOKS_ATTRIBUTE_TABLE

--- a/gcc/jit/dummy-frontend.cc
+++ b/gcc/jit/dummy-frontend.cc
@@ -1434,9 +1434,6 @@ jit_langhook_eh_personality (void)
 #undef LANG_HOOKS_GETDECLS
 #define LANG_HOOKS_GETDECLS		jit_langhook_getdecls
 
-#undef LANG_HOOKS_DWARF_NAME
-#define LANG_HOOKS_DWARF_NAME           jit_langhook_dwarf_name
-
 /* Attribute hooks.  */
 #undef LANG_HOOKS_ATTRIBUTE_TABLE
 #define LANG_HOOKS_ATTRIBUTE_TABLE jit_attribute_table

--- a/gcc/jit/dummy-frontend.cc
+++ b/gcc/jit/dummy-frontend.cc
@@ -1385,7 +1385,7 @@ jit_langhook_dwarf_name (tree decl, int verbosity)
       || !(decl
            && FUNCTION_DECL == TREE_CODE(decl)
            && (attr = lookup_attribute("jit_dwarf_short_name", DECL_ATTRIBUTES(decl)))
-           && (name = TREE_STRING_POINTER (TREE_VALUE (attr)))))
+           && (name = TREE_STRING_POINTER (TREE_VALUE(TREE_VALUE (attr))))))
     return lhd_dwarf_name (decl, verbosity);
   else
     return name;

--- a/gcc/jit/dummy-frontend.cc
+++ b/gcc/jit/dummy-frontend.cc
@@ -195,7 +195,7 @@ static const attribute_spec jit_gnu_attributes[] =
 			      attr_returns_twice_exclusions },
   { "sentinel",		      0, 1, false, true, true, false,
 			      handle_sentinel_attribute, NULL },
-  { "short_name",	      0, 0, false,  false, false, false,
+  { "short_name",	      0, 1, false,  false, false, false,
 			      NULL, NULL },
   { "target",		      1, -1, true, false, false, false,
 			      handle_target_attribute, attr_target_exclusions },

--- a/gcc/jit/dummy-frontend.cc
+++ b/gcc/jit/dummy-frontend.cc
@@ -195,6 +195,8 @@ static const attribute_spec jit_gnu_attributes[] =
 			      attr_returns_twice_exclusions },
   { "sentinel",		      0, 1, false, true, true, false,
 			      handle_sentinel_attribute, NULL },
+  { "short_name",	      0, 0, false,  false, false, false,
+			      NULL, NULL },
   { "target",		      1, -1, true, false, false, false,
 			      handle_target_attribute, attr_target_exclusions },
   { "type generic",	      0, 0, false, true, true, false,

--- a/gcc/jit/jit-common.h
+++ b/gcc/jit/jit-common.h
@@ -148,6 +148,7 @@ namespace recording {
     class statement;
       class extended_asm;
     class case_;
+    class debug_namespace;
   class top_level_asm;
 
   /* End of recording types. */
@@ -171,6 +172,7 @@ namespace playback {
     class source_line;
     class location;
     class case_;
+    class debug_namespace;
 
   /* End of playback types. */
 }

--- a/gcc/jit/jit-playback.cc
+++ b/gcc/jit/jit-playback.cc
@@ -2253,6 +2253,13 @@ set_personality_function (function *personality_function)
   DECL_FUNCTION_PERSONALITY (m_inner_fndecl) = personality_function->as_fndecl ();
 }
 
+
+void
+playback::function::set_parent_debug_namespace(tree parent_dbg_ns)
+{
+  DECL_CONTEXT(this->m_inner_fndecl) = parent_dbg_ns;
+}
+
 /* Build a statement list for the function as a whole out of the
    lists of statements for the individual blocks, building labels
    for each block.  */
@@ -4159,6 +4166,27 @@ playback::location::location (recording::location *loc,
   m_line (line),
   m_column_num(column_num)
 {
+}
+
+/* Construct a playback::field instance (wrapping a tree).  */
+
+playback::debug_namespace *
+playback::context::
+new_debug_namespace (recording::debug_namespace *dbg_ns)
+{
+  gcc_assert(dbg_ns->get_name());
+
+  tree decl = build_decl (UNKNOWN_LOCATION, NAMESPACE_DECL,
+			  get_identifier (dbg_ns->get_name()), void_type_node);
+
+  if (dbg_ns->get_parent())
+    DECL_CONTEXT(decl) =
+      dbg_ns
+      ->get_parent()
+      ->get_playback_obj()
+      ->as_tree();
+
+  return new debug_namespace (decl);
 }
 
 /* The active gcc::jit::playback::context instance.  This is a singleton,

--- a/gcc/jit/jit-playback.cc
+++ b/gcc/jit/jit-playback.cc
@@ -550,8 +550,8 @@ const char* fn_attribute_to_string (gcc_jit_fn_attribute attr)
       return "weak";
     case GCC_JIT_FN_ATTRIBUTE_NONNULL:
       return "nonnull";
-    case GCC_JIT_FN_ATTRIBUTE_SHORT_NAME:
-      return "short_name";
+    case GCC_JIT_FN_ATTRIBUTE_JIT_DWARF_SHORT_NAME:
+      return "jit_dwarf_short_name";
     case GCC_JIT_FN_ATTRIBUTE_MAX:
       return NULL;
   }
@@ -711,7 +711,7 @@ new_function (location *loc,
     const char* attribute = fn_attribute_to_string (name);
     tree ident = attribute ? get_identifier (attribute) : NULL;
 
-    if (should_test_short_name && GCC_JIT_FN_ATTRIBUTE_SHORT_NAME == name) {
+    if (should_test_short_name && GCC_JIT_FN_ATTRIBUTE_JIT_DWARF_SHORT_NAME == name) {
         short_name_found = true;
         should_test_short_name = false;
     }

--- a/gcc/jit/jit-playback.cc
+++ b/gcc/jit/jit-playback.cc
@@ -698,6 +698,10 @@ new_function (location *loc,
     }
   }
 
+  bool short_name_found = false;
+  bool should_test_short_name = get_bool_option(GCC_JIT_BOOL_OPTION_DEBUGINFO)
+      && get_bool_option(GCC_JIT_BOOL_OPTION_MANGLED_FUNCTION_NAME);
+
   for (auto attr: string_attributes)
   {
     gcc_jit_fn_attribute& name = std::get<0>(attr);
@@ -707,8 +711,18 @@ new_function (location *loc,
     const char* attribute = fn_attribute_to_string (name);
     tree ident = attribute ? get_identifier (attribute) : NULL;
 
+    if (should_test_short_name && GCC_JIT_FN_ATTRIBUTE_SHORT_NAME == name) {
+        short_name_found = true;
+        should_test_short_name = false;
+    }
+
     if (ident)
       fn_attributes = tree_cons (ident, attribute_value, fn_attributes);
+  }
+
+  if (short_name_found)
+  {
+    SET_DECL_ASSEMBLER_NAME(fndecl, get_identifier(name));
   }
 
   for (auto attr: int_array_attributes)

--- a/gcc/jit/jit-playback.cc
+++ b/gcc/jit/jit-playback.cc
@@ -698,10 +698,6 @@ new_function (location *loc,
     }
   }
 
-  bool short_name_found = false;
-  bool should_test_short_name = get_bool_option(GCC_JIT_BOOL_OPTION_DEBUGINFO)
-      && get_bool_option(GCC_JIT_BOOL_OPTION_MANGLED_FUNCTION_NAME);
-
   for (auto attr: string_attributes)
   {
     gcc_jit_fn_attribute& name = std::get<0>(attr);
@@ -711,18 +707,8 @@ new_function (location *loc,
     const char* attribute = fn_attribute_to_string (name);
     tree ident = attribute ? get_identifier (attribute) : NULL;
 
-    if (should_test_short_name && GCC_JIT_FN_ATTRIBUTE_JIT_DWARF_SHORT_NAME == name) {
-        short_name_found = true;
-        should_test_short_name = false;
-    }
-
     if (ident)
       fn_attributes = tree_cons (ident, attribute_value, fn_attributes);
-  }
-
-  if (short_name_found)
-  {
-    SET_DECL_ASSEMBLER_NAME(fndecl, get_identifier(name));
   }
 
   for (auto attr: int_array_attributes)

--- a/gcc/jit/jit-playback.cc
+++ b/gcc/jit/jit-playback.cc
@@ -550,6 +550,8 @@ const char* fn_attribute_to_string (gcc_jit_fn_attribute attr)
       return "weak";
     case GCC_JIT_FN_ATTRIBUTE_NONNULL:
       return "nonnull";
+    case GCC_JIT_FN_ATTRIBUTE_SHORT_NAME:
+      return "short_name";
     case GCC_JIT_FN_ATTRIBUTE_MAX:
       return NULL;
   }

--- a/gcc/jit/jit-playback.h
+++ b/gcc/jit/jit-playback.h
@@ -25,6 +25,7 @@ along with GCC; see the file COPYING3.  If not see
 #include <utility> // for std::pair
 #include <vector>
 
+#include "jit-common.h"
 #include "timevar.h"
 #include "varasm.h"
 
@@ -252,6 +253,9 @@ public:
   void
   set_bool_option (enum gcc_jit_bool_option opt,
 		   int value);
+
+  debug_namespace *
+  new_debug_namespace (recording::debug_namespace *dbg_ns);
 
   const char *
   get_str_option (enum gcc_jit_str_option opt) const
@@ -523,6 +527,19 @@ private:
   tree m_inner;
 };
 
+class debug_namespace : public wrapper
+{
+public:
+  debug_namespace (tree inner)
+    : m_inner(inner)
+  {}
+
+  tree as_tree () const { return m_inner; }
+
+private:
+  tree m_inner;
+};
+
 class compound_type : public type
 {
 public:
@@ -581,6 +598,9 @@ public:
 
   void
   build_stmt_list ();
+
+  void
+  set_parent_debug_namespace(tree parent_dbg_ns);
 
   void
   postprocess ();

--- a/gcc/jit/jit-recording.cc
+++ b/gcc/jit/jit-recording.cc
@@ -29,6 +29,7 @@ along with GCC; see the file COPYING3.  If not see
 #include "jit-builtins.h"
 #include "jit-recording.h"
 #include "jit-playback.h"
+#include "langhooks.h"
 #include <sstream>
 
 /* This comes from diagnostic.cc.  */
@@ -38,6 +39,10 @@ static const char *const diagnostic_kind_text[] = {
 #undef DEFINE_DIAGNOSTIC_KIND
   "must-not-happen"
 };
+
+extern struct lang_hooks lang_hooks;
+extern const char * jit_langhook_dwarf_name (tree decl, int verbosity);
+extern const char * lhd_dwarf_name (tree decl, int verbosity);
 
 namespace gcc {
 namespace jit {
@@ -1520,6 +1525,8 @@ recording::context::set_bool_option (enum gcc_jit_bool_option opt,
       return;
     }
   m_bool_options[opt] = value ? true : false;
+  if (GCC_JIT_BOOL_OPTION_MANGLED_FUNCTION_NAME == opt)
+    lang_hooks.dwarf_name = m_bool_options[opt] ? jit_langhook_dwarf_name : lhd_dwarf_name;
   log_bool_option (opt);
 }
 
@@ -1877,6 +1884,7 @@ static const char * const
   "GCC_JIT_BOOL_OPTION_DUMP_EVERYTHING",
   "GCC_JIT_BOOL_OPTION_SELFCHECK_GC",
   "GCC_JIT_BOOL_OPTION_KEEP_INTERMEDIATES",
+  "GCC_JIT_BOOL_OPTION_MANGLED_FUNCTION_NAME"
 };
 
 static const char * const

--- a/gcc/jit/libgccjit.cc
+++ b/gcc/jit/libgccjit.cc
@@ -113,6 +113,9 @@ struct gcc_jit_extended_asm : public gcc::jit::recording::extended_asm
 {
 };
 
+struct gcc_jit_debug_namespace : public gcc::jit::recording::debug_namespace
+{
+};
 
 /**********************************************************************
  Error-handling.
@@ -1791,6 +1794,15 @@ gcc_jit_context_new_array_constructor (gcc_jit_context *ctxt,
     num_values,
     NULL,
     reinterpret_cast<gcc::jit::recording::rvalue**>(values));
+}
+
+
+gcc_jit_debug_namespace *
+gcc_jit_context_new_debug_namespace (gcc_jit_context *ctxt, const char *name, gcc_jit_debug_namespace *parent)
+{
+  return (gcc_jit_debug_namespace*)ctxt->new_debug_namespace (
+    name,
+    (gcc::jit::recording::debug_namespace*) parent);
 }
 
 /* Public entrypoint.  See description in libgccjit.h.
@@ -4791,4 +4803,12 @@ gcc_jit_function_set_location (gcc_jit_function *func,
   RETURN_IF_FAIL (func, NULL, NULL, "NULL func");
 
   func->set_loc (loc);
+}
+
+void
+gcc_jit_function_set_parent_debug_namespace(gcc_jit_function *func,
+                                            gcc_jit_debug_namespace *dbg_namespace)
+{
+  RETURN_IF_FAIL (func, NULL, NULL, "NULL func");
+  func->set_parent_debug_namespace(dbg_namespace);
 }

--- a/gcc/jit/libgccjit.h
+++ b/gcc/jit/libgccjit.h
@@ -250,7 +250,7 @@ enum gcc_jit_bool_option
   /* If true, gcc_jit_context will treat the function names
      as mangled by default, setting the linking name trough
      SET_DECL_ASSEMBLER_NAME, unless the function is of a
-     GCC_JIT_FN_ATTRIBUTE_SHORT_NAME attribute without any argument.
+     GCC_JIT_FN_ATTRIBUTE_JIT_DWARF_SHORT_NAME attribute without any argument.
      NOTE:
      1. This option is ignored if GCC_JIT_DEBUGINFO is false.
      2. This option must be set before the GIMPLE tree is built.*/
@@ -2132,7 +2132,7 @@ enum gcc_jit_fn_attribute
   GCC_JIT_FN_ATTRIBUTE_CONST,
   GCC_JIT_FN_ATTRIBUTE_WEAK,
   GCC_JIT_FN_ATTRIBUTE_NONNULL,
-  GCC_JIT_FN_ATTRIBUTE_SHORT_NAME,
+  GCC_JIT_FN_ATTRIBUTE_JIT_DWARF_SHORT_NAME,
 
   /* Maximum value of this enum, should always be last. */
   GCC_JIT_FN_ATTRIBUTE_MAX,

--- a/gcc/jit/libgccjit.h
+++ b/gcc/jit/libgccjit.h
@@ -247,7 +247,16 @@ enum gcc_jit_bool_option
      their location on stderr.  */
   GCC_JIT_BOOL_OPTION_KEEP_INTERMEDIATES,
 
-  GCC_JIT_NUM_BOOL_OPTIONS
+  /* If true, gcc_jit_context will treat the function names
+     as mangled by default, setting the linking name trough
+     SET_DECL_ASSEMBLER_NAME, unless the function is of
+     GCC_JIT_FN_ATTRIBUTE_NO_MANGLE attribute.
+     NOTE:
+     1. This option is ignored if GCC_JIT_DEBUGINFO is false.
+     2. This option must be set before the GIMPLE tree is built.*/
+  GCC_JIT_BOOL_OPTION_MANGLED_FUNCTION_NAME,
+
+  GCC_JIT_NUM_BOOL_OPTIONS,
 };
 
 /* Set a string option on the given context.
@@ -2123,6 +2132,7 @@ enum gcc_jit_fn_attribute
   GCC_JIT_FN_ATTRIBUTE_CONST,
   GCC_JIT_FN_ATTRIBUTE_WEAK,
   GCC_JIT_FN_ATTRIBUTE_NONNULL,
+  GCC_JIT_FN_ATTRIBUTE_NOMANGLE,
 
   /* Maximum value of this enum, should always be last. */
   GCC_JIT_FN_ATTRIBUTE_MAX,

--- a/gcc/jit/libgccjit.h
+++ b/gcc/jit/libgccjit.h
@@ -249,8 +249,8 @@ enum gcc_jit_bool_option
 
   /* If true, gcc_jit_context will treat the function names
      as mangled by default, setting the linking name trough
-     SET_DECL_ASSEMBLER_NAME, unless the function is of
-     GCC_JIT_FN_ATTRIBUTE_NO_MANGLE attribute.
+     SET_DECL_ASSEMBLER_NAME, unless the function is of a
+     GCC_JIT_FN_ATTRIBUTE_SHORT_NAME attribute without any argument.
      NOTE:
      1. This option is ignored if GCC_JIT_DEBUGINFO is false.
      2. This option must be set before the GIMPLE tree is built.*/
@@ -2132,7 +2132,7 @@ enum gcc_jit_fn_attribute
   GCC_JIT_FN_ATTRIBUTE_CONST,
   GCC_JIT_FN_ATTRIBUTE_WEAK,
   GCC_JIT_FN_ATTRIBUTE_NONNULL,
-  GCC_JIT_FN_ATTRIBUTE_NOMANGLE,
+  GCC_JIT_FN_ATTRIBUTE_SHORT_NAME,
 
   /* Maximum value of this enum, should always be last. */
   GCC_JIT_FN_ATTRIBUTE_MAX,

--- a/gcc/jit/libgccjit.h
+++ b/gcc/jit/libgccjit.h
@@ -156,6 +156,15 @@ typedef struct gcc_jit_case gcc_jit_case;
    outputs.  */
 typedef struct gcc_jit_extended_asm gcc_jit_extended_asm;
 
+
+/* A gcc_jit_namespace represents a bare namespace that is to be exported as
+   a namespace in dwarf debug info. The reason for such a structure is that
+   a context may bring the same effect but it requires a strict order of
+   compilation. By constrast, this struct does not impose such a requirement
+   to compilation.
+ */
+typedef struct gcc_jit_debug_namespace gcc_jit_debug_namespace;
+
 /* Acquire a JIT-compilation context.  */
 extern gcc_jit_context *
 gcc_jit_context_acquire (void);
@@ -2202,6 +2211,18 @@ gcc_jit_function_set_location (gcc_jit_function *func,
 extern void
 gcc_jit_rvalue_set_location (gcc_jit_rvalue *rvalue,
 			     gcc_jit_location *loc);
+
+
+/*
+   Build a debug namespace from its name, associating it with its parent.*/
+extern gcc_jit_debug_namespace *
+gcc_jit_context_new_debug_namespace (gcc_jit_context *ctxt,
+				     const char *name,
+				     gcc_jit_debug_namespace *parent);
+
+extern void
+gcc_jit_function_set_parent_debug_namespace(gcc_jit_function *func,
+					    gcc_jit_debug_namespace *dbg_namespace);
 
 #ifdef __cplusplus
 }

--- a/gcc/jit/libgccjit.map
+++ b/gcc/jit/libgccjit.map
@@ -347,3 +347,9 @@ LIBGCCJIT_ABI_37 {
     gcc_jit_function_set_location;
     gcc_jit_rvalue_set_location;
 } LIBGCCJIT_ABI_36;
+
+LIBGCCJIT_ABI_38 {
+   global:
+    gcc_jit_context_new_debug_namespace;
+    gcc_jit_function_set_parent_debug_namespace;
+} LIBGCCJIT_ABI_37;


### PR DESCRIPTION
# TL;DR
This series of commit is to provide a temporary workaround for demangling of cg_gcc.  It will enable the demangling in GDB for backtrace & function names but DISABLE the mangled name printing even with `set print demangle off`.

# Dependency
Required BY rust-lang/gccjit.rs#31

# Details
This part of code will be used even in the final version that supports both demangled and mangled names.

Currently this will disable the generation of mangled name information (just for GCCJIT, if the option `GCC_JIT_BOOL_OPTION_MANGLED_FUNCTION_NAME` is set, making it of NO overhead for those who don't use this option.)
(In my case, when co-generating both the mangled name(as `DW_AT_linkage_name`) and the function name (as `DW_AT_name`) are generated, the GDB will only print the DW_AT_name for a backtrace, despite the DW_AT_lang. However, this problem doesn't turn up in LLVM-generated code).
 
Further research and research is still to be done over how exactly GDB decides whether to demangle the functions names.