### PR TITLE
Target Info extended with supported types (limited to Float16|32|64|128)

### DIFF
--- a/gcc/config/i386/i386-jit.cc
+++ b/gcc/config/i386/i386-jit.cc
@@ -23,6 +23,7 @@ along with GCC; see the file COPYING3.  If not see
 #include "target.h"
 #include "tm.h"
 #include "tm_jit.h"
+#include "tree.h"
 #include "jit/jit-target.h"
 #include "jit/jit-target-def.h"
 
@@ -69,6 +70,18 @@ ix86_jit_register_target_info (void)
   jit_target_set_arch (cpu);
 
   jit_target_set_128bit_int_support (targetm.scalar_mode_supported_p (TImode));
+
+  if (float16_type_node != NULL && TYPE_PRECISION(float16_type_node) == 16)
+    jit_target_add_supported_target_dependent_type(GCC_JIT_TYPE_FLOAT16);
+
+  if (float32_type_node != NULL && TYPE_PRECISION(float32_type_node) == 32)
+    jit_target_add_supported_target_dependent_type(GCC_JIT_TYPE_FLOAT32);
+
+  if (float64_type_node != NULL && TYPE_PRECISION(float64_type_node) == 64)
+    jit_target_add_supported_target_dependent_type(GCC_JIT_TYPE_FLOAT64);
+  
+  if (float128_type_node != NULL && TYPE_PRECISION(float128_type_node) == 128)
+    jit_target_add_supported_target_dependent_type(GCC_JIT_TYPE_FLOAT128);
 
   if (TARGET_MMX)
     jit_add_target_info ("target_feature", "mmx");

--- a/gcc/jit/jit-target.cc
+++ b/gcc/jit/jit-target.cc
@@ -70,6 +70,12 @@ jit_target_set_128bit_int_support (bool support)
   jit_target_info.m_supports_128bit_int = support;
 }
 
+void
+jit_target_add_supported_target_dependent_type(enum gcc_jit_types type_)
+{
+  jit_target_info.m_supported_target_dependent_types.insert(type_);
+}
+
 target_info *
 jit_get_target_info ()
 {

--- a/gcc/jit/jit-target.h
+++ b/gcc/jit/jit-target.h
@@ -24,6 +24,7 @@
 #define HOOKSTRUCT(FRAGMENT) FRAGMENT
 
 #include "jit-target.def"
+#include "libgccjit.h"
 
 #include <string>
 #include <unordered_map>
@@ -55,6 +56,7 @@ struct target_info {
     std::unordered_map<const char *, std::unordered_set<const char *, CStringHash, CStringEqual>, CStringHash, CStringEqual> m_info;
     std::string m_arch;
     bool m_supports_128bit_int = false;
+    std::unordered_set<enum gcc_jit_types> m_supported_target_dependent_types;
 };
 
 /* Each target can provide their own.  */
@@ -63,6 +65,7 @@ extern struct gcc_targetjitm targetjitm;
 extern void jit_target_init ();
 extern void jit_target_set_arch (std::string const& arch);
 extern void jit_target_set_128bit_int_support (bool support);
+extern void jit_target_add_supported_target_dependent_type(enum gcc_jit_types type_);
 extern void jit_add_target_info (const char *key, const char *value);
 extern target_info * jit_get_target_info ();
 

--- a/gcc/jit/libgccjit.cc
+++ b/gcc/jit/libgccjit.cc
@@ -4012,6 +4012,12 @@ gcc_jit_target_info_supports_128bit_int (gcc_jit_target_info *info)
   return info->m_supports_128bit_int;
 }
 
+int
+gcc_jit_target_info_supports_target_dependent_type(gcc_jit_target_info *info, enum gcc_jit_types type)
+{
+  return info->m_supported_target_dependent_types.find(type) != info->m_supported_target_dependent_types.end();
+}
+
 /* Public entrypoint.  See description in libgccjit.h.
 
    After error-checking, the real work is done by the

--- a/gcc/jit/libgccjit.h
+++ b/gcc/jit/libgccjit.h
@@ -2196,6 +2196,9 @@ gcc_jit_target_info_arch (gcc_jit_target_info *info);
 extern int
 gcc_jit_target_info_supports_128bit_int (gcc_jit_target_info *info);
 
+extern int
+gcc_jit_target_info_supports_target_dependent_type(gcc_jit_target_info *info, enum gcc_jit_types type);
+
 /* Given type "T", get type "T __attribute__ ((packed))".  */
 extern void
 gcc_jit_type_set_packed (gcc_jit_type *type);

--- a/gcc/jit/libgccjit.map
+++ b/gcc/jit/libgccjit.map
@@ -352,3 +352,8 @@ LIBGCCJIT_ABI_38 {
   global:
     gcc_jit_context_new_alignof;
 } LIBGCCJIT_ABI_37;
+
+LIBGCCJIT_ABI_39 {
+  global:
+    gcc_jit_target_info_supports_target_dependent_type;
+} LIBGCCJIT_ABI_38;

--- a/patches/0001-Disable-128-bit-integers-for-testing-purposes.patch
+++ b/patches/0001-Disable-128-bit-integers-for-testing-purposes.patch
@@ -1,7 +1,7 @@
-From f8f19b4749ef849c814cb24c104e53c991488310 Mon Sep 17 00:00:00 2001
-From: Antoni Boucher <bouanto@zoho.com>
-Date: Fri, 16 Feb 2024 12:04:40 -0500
-Subject: [PATCH] Disable 128-bit integers for testing purposes
+From 252013d4d77dea9ce2078642d721d7ab906075ac Mon Sep 17 00:00:00 2001
+From: Robert Zakrzewski <robert.zakrzewski1@stellantis.com>
+Date: Fri, 19 Apr 2024 16:21:56 +0200
+Subject: [PATCH] Disable 128 bit integers for testing purposes
 
 ---
  gcc/config/i386/i386-jit.cc | 2 +-
@@ -9,20 +9,20 @@ Subject: [PATCH] Disable 128-bit integers for testing purposes
  2 files changed, 5 insertions(+), 5 deletions(-)
 
 diff --git a/gcc/config/i386/i386-jit.cc b/gcc/config/i386/i386-jit.cc
-index 49e54aa7990..67c50bdc6dd 100644
+index 8c7c8cd45e8..2dc35b6a746 100644
 --- a/gcc/config/i386/i386-jit.cc
 +++ b/gcc/config/i386/i386-jit.cc
-@@ -68,7 +68,7 @@ ix86_jit_register_target_info (void)
+@@ -69,7 +69,7 @@ ix86_jit_register_target_info (void)
    std::string cpu = arch.substr (arg_pos, end_pos - arg_pos);
    jit_target_set_arch (cpu);
  
 -  jit_target_set_128bit_int_support (targetm.scalar_mode_supported_p (TImode));
 +  //jit_target_set_128bit_int_support (targetm.scalar_mode_supported_p (TImode));
  
-   if (TARGET_MMX)
-     jit_add_target_info ("target_feature", "mmx");
+   if (float16_type_node != NULL && TYPE_PRECISION(float16_type_node) == 16)
+     jit_target_add_supported_target_dependent_type(GCC_JIT_TYPE_FLOAT16);
 diff --git a/gcc/jit/jit-playback.cc b/gcc/jit/jit-playback.cc
-index 6b0522d6f88..73efa6b5bc0 100644
+index 625af722741..a6ddfa179d0 100644
 --- a/gcc/jit/jit-playback.cc
 +++ b/gcc/jit/jit-playback.cc
 @@ -249,8 +249,8 @@ get_tree_node_for_type (enum gcc_jit_types type_)
@@ -48,5 +48,5 @@ index 6b0522d6f88..73efa6b5bc0 100644
        add_error (NULL, "gcc_jit_types value unsupported on this target: %i",
  		 type_);
 -- 
-2.43.0
+2.25.1
 


### PR DESCRIPTION
Target info extended with:

- map of supported types
- function to register supported type (`jit_target_add_supported_type`)
- function to check if type is supported (`gcc_jit_target_info_supports_type`)
