### PR TITLE
Make is_same_type_as() supporting floating point types. Improve type coparison.

### DIFF
--- a/gcc/jit/jit-recording.h
+++ b/gcc/jit/jit-recording.h
@@ -634,8 +634,7 @@ public:
 
   virtual bool is_same_type_as (type *other)
   {
-    if (is_int ()
-		 && other->is_int ()
+    if ((is_int () && other->is_int () || is_float() && other->is_float())
 		 && get_size () == other->get_size ()
 		 && is_signed () == other->is_signed ())
     {

--- a/gcc/jit/libgccjit.cc
+++ b/gcc/jit/libgccjit.cc
@@ -2331,7 +2331,7 @@ gcc_jit_context_new_comparison (gcc_jit_context *ctxt,
   RETURN_NULL_IF_FAIL (a, ctxt, loc, "NULL a");
   RETURN_NULL_IF_FAIL (b, ctxt, loc, "NULL b");
   RETURN_NULL_IF_FAIL_PRINTF4 (
-    a->get_type ()->unqualified () == b->get_type ()->unqualified (),
+    compatible_types(a->get_type()->unqualified(), b->get_type()->unqualified()),
     ctxt, loc,
     "mismatching types for comparison:"
     " a: %s (type: %s) b: %s (type: %s)",


### PR DESCRIPTION
- `is_same_type_as()` now compares floating point types using their attributes
- `gcc_jit_context_new_comparison()` now uses `compatible_types()` to check for type compatible,
