### PR TITLE
Add patch to compile and link default-jit.o

### DIFF
--- a/gcc/Makefile.in
+++ b/gcc/Makefile.in
@@ -2422,6 +2422,12 @@ default-d.o: config/default-d.cc
 	$(COMPILE) $<
 	$(POSTCOMPILE)
 
+# Files used by the JIT language front end.
+
+default-jit.o: config/default-jit.cc
+	$(COMPILE) $<
+	$(POSTCOMPILE)
+
 # Files used by the Rust language front end.
 
 default-rust.o: config/default-rust.cc


### PR DESCRIPTION
@antoyo was to submit this patch from @YakoYakoYokuYoku upstream, see references:
1. https://gcc.gnu.org/pipermail/jit/2023q4/001765.html
2. https://patchwork.sourceware.org/project/gcc/patch/8b0199d9835f568b7bcde41bf9432c21f604e489.camel@zoho.com/#164087

However,
1. It never made it to this gcc fork repo. Could it be added? Its absence causes many platforms to not build (AVR, SH...). This PR contains the cherry-picked commit retaining @YakoYakoYokuYoku's authorship. 
2. Even though @antoyo mentioned that he updated the patch on the Patchwork page above, the changes do not seem to be in the patch listed. Perhaps I'm just not seeing it; I'm not very familiar with the Patchwork system. Just wanted to check and make sure this didn't fall through the cracks. 
