### PR TITLE
Expose `va_arg` and `va_start`

### DIFF
--- a/gcc/jit/dummy-frontend.cc
+++ b/gcc/jit/dummy-frontend.cc
@@ -1486,8 +1486,28 @@ jit_langhook_eh_personality (void)
   return personality_decl;
 }
 
+static tree
+jit_langhook_type_promotes_to (tree type)
+{
+  /* The "default argument promotions" */
+
+  /* float is promoted to double. */
+  if (TYPE_MAIN_VARIANT (type) == float_type_node)
+    return double_type_node;
+
+  /* integers smaller than int are promoted to int. */
+  if (INTEGRAL_TYPE_P (type)
+      && TYPE_PRECISION (type) < TYPE_PRECISION (integer_type_node))
+    return integer_type_node;
+
+  return type;
+}
+
 #undef LANG_HOOKS_EH_PERSONALITY
 #define LANG_HOOKS_EH_PERSONALITY jit_langhook_eh_personality
+
+#undef LANG_HOOKS_TYPE_PROMOTES_TO
+#define LANG_HOOKS_TYPE_PROMOTES_TO jit_langhook_type_promotes_to
 
 #undef LANG_HOOKS_NAME
 #define LANG_HOOKS_NAME		"libgccjit"

--- a/gcc/jit/jit-builtins.cc
+++ b/gcc/jit/jit-builtins.cc
@@ -539,7 +539,8 @@ builtins_manager::make_primitive_type (enum jit_builtin_type type_id)
     // case BT_DFLOAT32:
     // case BT_DFLOAT64:
     // case BT_DFLOAT128:
-    // case BT_VALIST_REF:
+    case BT_VALIST_REF:
+      return m_ctxt->get_type (GCC_JIT_TYPE_VA_LIST)->get_pointer ();
     // case BT_VALIST_ARG:
     case BT_I1: return m_ctxt->get_int_type (1, true);
     case BT_I2: return m_ctxt->get_int_type (2, true);

--- a/gcc/jit/jit-common.h
+++ b/gcc/jit/jit-common.h
@@ -36,7 +36,7 @@ along with GCC; see the file COPYING3.  If not see
 #endif
 #endif
 
-const int NUM_GCC_JIT_TYPES = GCC_JIT_TYPE_FLOAT128 + 1;
+const int NUM_GCC_JIT_TYPES = GCC_JIT_TYPE_VA_LIST + 1;
 
 /* This comment is included by the docs.
 

--- a/gcc/jit/jit-playback.cc
+++ b/gcc/jit/jit-playback.cc
@@ -215,6 +215,9 @@ get_tree_node_for_type (enum gcc_jit_types type_)
     case GCC_JIT_TYPE_VOID:
       return void_type_node;
 
+    case GCC_JIT_TYPE_VA_LIST:
+      return va_list_type_node;
+
     case GCC_JIT_TYPE_VOID_PTR:
       return ptr_type_node;
 
@@ -1770,6 +1773,22 @@ new_bitcast (location *loc,
   if (loc)
     set_tree_location (t_bitcast, loc);
   return new rvalue (this, t_bitcast);
+}
+
+/* Construct a playback::rvalue instance (wrapping a tree) for a
+   va_arg expression. */
+
+playback::rvalue *
+playback::context::
+new_va_arg (location *loc,
+	    rvalue *ap,
+	    type *type_)
+{
+  tree t_va_arg = build1 (VA_ARG_EXPR, type_->as_tree (), ap->as_tree ());
+
+  if (loc)
+    set_tree_location (t_va_arg, loc);
+  return new rvalue (this, t_va_arg);
 }
 
 /* Construct a playback::lvalue instance (wrapping a tree) for an

--- a/gcc/jit/jit-playback.h
+++ b/gcc/jit/jit-playback.h
@@ -237,6 +237,11 @@ public:
 	       rvalue *expr,
 	       type *type_);
 
+  rvalue *
+  new_va_arg (location *loc,
+	      rvalue *ap,
+	      type *type_);
+
   lvalue *
   new_array_access (location *loc,
 		    rvalue *ptr,

--- a/gcc/jit/jit-recording.cc
+++ b/gcc/jit/jit-recording.cc
@@ -1403,6 +1403,22 @@ recording::context::new_bitcast (location *loc,
   return result;
 }
 
+/* Create a recording::va_arg_expr instance and add it to this context's list
+   of mementos.
+
+   Implements the post-error-checking part of
+   gcc_jit_context_new_va_arg.  */
+
+recording::rvalue *
+recording::context::new_va_arg (location *loc,
+			       rvalue *ap,
+			       type *type_)
+{
+  recording::rvalue *result = new va_arg_expr (this, loc, ap, type_);
+  record (result);
+  return result;
+}
+
 /* Create a recording::call instance and add it to this context's list
    of mementos.
 
@@ -2794,6 +2810,9 @@ recording::memento_of_get_type::dereference ()
     {
     default: gcc_unreachable ();
 
+    case GCC_JIT_TYPE_VA_LIST:
+      return NULL;
+
     case GCC_JIT_TYPE_VOID:
       return NULL;
 
@@ -2858,6 +2877,9 @@ recording::memento_of_get_type::is_int () const
   switch (m_kind)
     {
     default: gcc_unreachable ();
+
+    case GCC_JIT_TYPE_VA_LIST:
+      return false;
 
     case GCC_JIT_TYPE_VOID:
       return false;
@@ -2927,6 +2949,9 @@ recording::memento_of_get_type::is_signed () const
     {
     default: gcc_unreachable ();
 
+    case GCC_JIT_TYPE_VA_LIST:
+      return false;
+
     case GCC_JIT_TYPE_SIGNED_CHAR:
     case GCC_JIT_TYPE_CHAR:
     case GCC_JIT_TYPE_SHORT:
@@ -2985,6 +3010,9 @@ recording::memento_of_get_type::is_float () const
   switch (m_kind)
     {
     default: gcc_unreachable ();
+
+    case GCC_JIT_TYPE_VA_LIST:
+      return false;
 
     case GCC_JIT_TYPE_VOID:
       return false;
@@ -3053,6 +3081,9 @@ recording::memento_of_get_type::is_bool () const
   switch (m_kind)
     {
     default: gcc_unreachable ();
+
+    case GCC_JIT_TYPE_VA_LIST:
+      return false;
 
     case GCC_JIT_TYPE_VOID:
       return false;
@@ -3176,6 +3207,7 @@ static const char * const get_type_strings[] = {
   "_Float32",     /* GCC_JIT_TYPE_FLOAT32 */
   "_Float64",     /* GCC_JIT_TYPE_FLOAT64 */
   "__float128",   /* GCC_JIT_TYPE_FLOAT128 */
+  "__builtin_va_list", /* GCC_JIT_TYPE_VA_LIST */
 };
 
 /* Implementation of recording::memento::make_debug_string for
@@ -3226,6 +3258,7 @@ static const char * const get_type_enum_strings[] = {
   "GCC_JIT_TYPE_FLOAT32",
   "GCC_JIT_TYPE_FLOAT64",
   "GCC_JIT_TYPE_FLOAT128",
+  "GCC_JIT_TYPE_VA_LIST",
 };
 
 void
@@ -6852,6 +6885,57 @@ recording::bitcast::write_reproducer (reproducer &r)
 	   r.get_identifier (m_loc),
 	   r.get_identifier_as_rvalue (m_rvalue),
 	   r.get_identifier_as_type (get_type ()));
+}
+
+/* Implementation of pure virtual hook recording::memento::replay_into
+   for recording::va_arg_expr.  */
+
+void
+recording::va_arg_expr::replay_into (replayer *r)
+{
+  set_playback_obj (r->new_va_arg (playback_location (r, m_loc),
+				  m_ap->playback_rvalue (),
+				  get_type ()->playback_type ()));
+}
+
+/* Implementation of pure virtual hook recording::rvalue::visit_children
+   for recording::va_arg_expr.  */
+void
+recording::va_arg_expr::visit_children (rvalue_visitor *v)
+{
+  v->visit (m_ap);
+}
+
+/* Implementation of recording::memento::make_debug_string for
+   va_arg expressions.  */
+
+recording::string *
+recording::va_arg_expr::make_debug_string ()
+{
+  enum precedence prec = get_precedence ();
+  return string::from_printf (m_ctxt,
+			     "va_arg (%s, %s)",
+			     m_ap->get_debug_string_parens (prec),
+			     get_type ()->get_debug_string ());
+}
+
+/* Implementation of recording::memento::write_reproducer for va_arg
+   expressions.  */
+
+void
+recording::va_arg_expr::write_reproducer (reproducer &r)
+{
+  const char *id = r.make_identifier (this, "rvalue");
+  r.write ("  gcc_jit_rvalue *%s =\n"
+	  "    gcc_jit_context_new_va_arg (%s,\n"
+	  "                                %s, /* gcc_jit_location *loc */\n"
+	  "                                %s, /* gcc_jit_rvalue *ap */\n"
+	  "                                %s); /* gcc_jit_type *type */\n",
+	  id,
+	  r.get_identifier (get_context ()),
+	  r.get_identifier (m_loc),
+	  r.get_identifier_as_rvalue (m_ap),
+	  r.get_identifier_as_type (get_type ()));
 }
 
 /* The implementation of class gcc::jit::recording::base_call.  */

--- a/gcc/jit/jit-recording.h
+++ b/gcc/jit/jit-recording.h
@@ -242,6 +242,11 @@ public:
 	       rvalue *expr,
 	       type *type_);
 
+  rvalue *
+  new_va_arg (location *loc,
+	     rvalue *ap,
+	     type *type_);
+
   lvalue *
   new_array_access (location *loc,
 		    rvalue *ptr,
@@ -2212,6 +2217,33 @@ private:
 
 private:
   rvalue *m_rvalue;
+};
+
+class va_arg_expr : public rvalue
+{
+public:
+  va_arg_expr (context *ctxt,
+	       location *loc,
+	       rvalue *ap,
+	       type *type_)
+  : rvalue (ctxt, loc, type_),
+    m_ap (ap)
+  {}
+
+  void replay_into (replayer *r) final override;
+
+  void visit_children (rvalue_visitor *v) final override;
+
+private:
+  string * make_debug_string () final override;
+  void write_reproducer (reproducer &r) final override;
+  enum precedence get_precedence () const final override
+  {
+    return PRECEDENCE_POSTFIX;
+  }
+
+private:
+  rvalue *m_ap;
 };
 
 class base_call : public rvalue

--- a/gcc/jit/libgccjit.cc
+++ b/gcc/jit/libgccjit.cc
@@ -2609,6 +2609,31 @@ gcc_jit_context_new_bitcast (gcc_jit_context *ctxt,
 /* Public entrypoint.  See description in libgccjit.h.
 
    After error-checking, the real work is done by the
+   gcc::jit::recording::context::new_va_arg method in jit-recording.cc.  */
+
+gcc_jit_rvalue *
+gcc_jit_context_new_va_arg (gcc_jit_context *ctxt,
+			    gcc_jit_location *loc,
+			    gcc_jit_rvalue *ap,
+			    gcc_jit_type *type)
+{
+  RETURN_NULL_IF_FAIL (ctxt, NULL, loc, "NULL context");
+  JIT_LOG_FUNC (ctxt->get_logger ());
+  /* LOC can be NULL.  */
+  RETURN_NULL_IF_FAIL (ap, ctxt, loc, "NULL ap");
+  RETURN_NULL_IF_FAIL (type, ctxt, loc, "NULL type");
+  RETURN_NULL_IF_FAIL_PRINTF1 (
+    ap->get_type ()->is_pointer (),
+    ctxt, loc,
+    "ap is not a pointer: %s",
+    ap->get_debug_string ());
+
+  return static_cast <gcc_jit_rvalue *> (ctxt->new_va_arg (loc, ap, type));
+}
+
+/* Public entrypoint.  See description in libgccjit.h.
+
+   After error-checking, the real work is done by the
    gcc::jit::recording::context::new_array_access method in
    jit-recording.cc.  */
 

--- a/gcc/jit/libgccjit.h
+++ b/gcc/jit/libgccjit.h
@@ -623,6 +623,9 @@ enum gcc_jit_types
   GCC_JIT_TYPE_FLOAT32,
   GCC_JIT_TYPE_FLOAT64,
   GCC_JIT_TYPE_FLOAT128,
+
+  /* C's "va_list" */
+  GCC_JIT_TYPE_VA_LIST,
 };
 
 extern gcc_jit_type *
@@ -1353,6 +1356,21 @@ gcc_jit_context_new_bitcast (gcc_jit_context *ctxt,
 			     gcc_jit_location *loc,
 			     gcc_jit_rvalue *rvalue,
 			     gcc_jit_type *type);
+
+#define LIBGCCJIT_HAVE_gcc_jit_context_new_va_arg
+
+/* Read the next argument of a variadic function.
+
+   This is equivalent to the C `va_arg (*ap, type)`.
+
+   This API entrypoint was added in LIBGCCJIT_ABI_50; you can test for its
+   presence using
+     #ifdef LIBGCCJIT_HAVE_gcc_jit_context_new_va_arg  */
+extern gcc_jit_rvalue *
+gcc_jit_context_new_va_arg (gcc_jit_context *ctxt,
+			   gcc_jit_location *loc,
+			   gcc_jit_rvalue *ap,
+			   gcc_jit_type *type);
 
 #define LIBGCCJIT_HAVE_ALIGNMENT
 

--- a/gcc/jit/libgccjit.map
+++ b/gcc/jit/libgccjit.map
@@ -409,3 +409,8 @@ LIBGCCJIT_ABI_49 {
     gcc_jit_set_lang_name;
     gcc_jit_context_set_filename;
 } LIBGCCJIT_ABI_48;
+
+LIBGCCJIT_ABI_50 {
+  global:
+    gcc_jit_context_new_va_arg;
+} LIBGCCJIT_ABI_49;


### PR DESCRIPTION
The bits we need to hook up `va_arg` and `va_start` in the GCC backend. I got this to work on `x86_64`, I've tried to not bake in assumptions about other platforms (e.g. the layout of `VaList`), but this code is pretty dense. 

I'll leave some comments on the non-boilerplate bits.