### PR TITLE
[libgccjit] Add support for `retain` attribute

### DIFF
--- a/gcc/jit/dummy-frontend.cc
+++ b/gcc/jit/dummy-frontend.cc
@@ -61,6 +61,7 @@ static tree handle_novops_attribute (tree *, tree, tree, int, bool *);
 static tree handle_patchable_function_entry_attribute (tree *, tree, tree,
 						       int, bool *);
 static tree handle_pure_attribute (tree *, tree, tree, int, bool *);
+static tree handle_retain_attribute (tree *, tree, tree, int, bool *);
 static tree handle_returns_twice_attribute (tree *, tree, tree, int, bool *);
 static tree handle_section_attribute (tree *, tree, tree, int, bool *);
 static tree handle_sentinel_attribute (tree *, tree, tree, int, bool *);
@@ -205,6 +206,8 @@ static const attribute_spec jit_gnu_attributes[] =
   { "pure",		      0, 0, true,  false, false, false,
 			      handle_pure_attribute,
 			      attr_const_pure_exclusions },
+  { "retain",                 0, 0, true,  false, false, false,
+			      handle_retain_attribute, NULL },
   { "returns_twice",	      0, 0, true,  false, false, false,
 			      handle_returns_twice_attribute,
 			      attr_returns_twice_exclusions },
@@ -1132,6 +1135,28 @@ handle_section_attribute (tree *node, tree name, tree args,
 fail:
   *no_add_attrs = true;
   return res;
+}
+
+/* Handle a "retain" attribute; arguments as in
+   struct attribute_spec.handler.  */
+
+static tree
+handle_retain_attribute (tree *pnode, tree name, tree ARG_UNUSED (args),
+			 int ARG_UNUSED (flags), bool *no_add_attrs)
+{
+  tree node = *pnode;
+
+  if (SUPPORTS_SHF_GNU_RETAIN
+      && (TREE_CODE (node) == FUNCTION_DECL
+	  || (VAR_P (node) && TREE_STATIC (node))))
+    ;
+  else
+    {
+      warning (OPT_Wattributes, "%qE attribute ignored", name);
+      *no_add_attrs = true;
+    }
+
+  return NULL_TREE;
 }
 
 /* (end of attribute-handling).  */

--- a/gcc/jit/jit-playback.cc
+++ b/gcc/jit/jit-playback.cc
@@ -578,6 +578,8 @@ const char* fn_attribute_to_string (gcc_jit_fn_attribute attr)
       return "target";
     case GCC_JIT_FN_ATTRIBUTE_USED:
       return "used";
+    case GCC_JIT_FN_ATTRIBUTE_RETAIN:
+      return "retain";
     case GCC_JIT_FN_ATTRIBUTE_VISIBILITY:
       return "visibility";
     case GCC_JIT_FN_ATTRIBUTE_COLD:
@@ -646,6 +648,8 @@ const char* variable_attribute_to_string (gcc_jit_variable_attribute attr)
       return "weak";
     case GCC_JIT_VARIABLE_ATTRIBUTE_SECTION:
       return "section";
+    case GCC_JIT_VARIABLE_ATTRIBUTE_RETAIN:
+      return "retain";
     case GCC_JIT_VARIABLE_ATTRIBUTE_MAX:
       return NULL;
   }

--- a/gcc/jit/jit-recording.cc
+++ b/gcc/jit/jit-recording.cc
@@ -5052,6 +5052,7 @@ static const char * const fn_attribute_reproducer_strings[] =
   "GCC_JIT_FN_ATTRIBUTE_X86_SYSV_ABI",
   "GCC_JIT_FN_ATTRIBUTE_X86_THIS_CALL",
   "GCC_JIT_FN_ATTRIBUTE_SECTION",
+  "GCC_JIT_FN_ATTRIBUTE_RETAIN",
 };
 
 std::string
@@ -5724,6 +5725,7 @@ static const char * const gcc_jit_variable_attribute_enum_strings[] = {
   "GCC_JIT_VARIABLE_ATTRIBUTE_ALIAS",
   "GCC_JIT_VARIABLE_ATTRIBUTE_USED",
   "GCC_JIT_VARIABLE_ATTRIBUTE_SECTION"
+  "GCC_JIT_VARIABLE_ATTRIBUTE_RETAIN",
 };
 
 void

--- a/gcc/jit/libgccjit.h
+++ b/gcc/jit/libgccjit.h
@@ -2235,6 +2235,7 @@ enum gcc_jit_fn_attribute
   GCC_JIT_FN_ATTRIBUTE_X86_THIS_CALL,
 
   GCC_JIT_FN_ATTRIBUTE_SECTION,
+  GCC_JIT_FN_ATTRIBUTE_RETAIN,
 
   /* Maximum value of this enum, should always be last. */
   GCC_JIT_FN_ATTRIBUTE_MAX,
@@ -2319,6 +2320,7 @@ enum gcc_jit_variable_attribute
   GCC_JIT_VARIABLE_ATTRIBUTE_ALIAS,
   GCC_JIT_VARIABLE_ATTRIBUTE_USED,
   GCC_JIT_VARIABLE_ATTRIBUTE_SECTION,
+  GCC_JIT_VARIABLE_ATTRIBUTE_RETAIN,
 
   /* Maximum value of this enum, should always be last. */
   GCC_JIT_VARIABLE_ATTRIBUTE_MAX,

--- a/gcc/testsuite/jit.dg/test-retain-attribute.c
+++ b/gcc/testsuite/jit.dg/test-retain-attribute.c
@@ -1,0 +1,61 @@
+/* { dg-do compile { target x86_64-*-* } } */
+
+#include <stdlib.h>
+#include <stdio.h>
+
+#include "libgccjit.h"
+
+#define TEST_ESCHEWS_SET_OPTIONS
+static void set_options (gcc_jit_context *ctxt, const char *argv0)
+{
+  // Set "-O2".
+  gcc_jit_context_set_int_option(ctxt, GCC_JIT_INT_OPTION_OPTIMIZATION_LEVEL, 2);
+}
+
+#define TEST_COMPILING_TO_FILE
+#define OUTPUT_KIND      GCC_JIT_OUTPUT_KIND_ASSEMBLER
+#define OUTPUT_FILENAME  "output-of-test-retain-attribute.c.s"
+#include "harness.h"
+
+void
+create_code (gcc_jit_context *ctxt, void *user_data)
+{
+  /* Let's try to inject the equivalent of:
+__attribute__((retain))
+int not_removed() { return 1; }
+const int blabla __attribute__((retain)) = 12;
+  */
+  gcc_jit_type *int_type =
+    gcc_jit_context_get_type (ctxt, GCC_JIT_TYPE_INT);
+
+  /* Creating the `not_removed` function. */
+    gcc_jit_function *not_removed_func =
+    gcc_jit_context_new_function (ctxt, NULL,
+	  GCC_JIT_FUNCTION_INTERNAL,
+	  int_type,
+	  "not_removed",
+	  0, NULL,
+	  0);
+
+  gcc_jit_block *foo_block = gcc_jit_function_new_block (not_removed_func,
+							 NULL);
+  gcc_jit_block_end_with_return (foo_block, NULL,
+    gcc_jit_context_new_rvalue_from_int (ctxt, int_type, 1));
+  /* __attribute__ ((retain)) */
+  gcc_jit_function_add_attribute(not_removed_func, GCC_JIT_FN_ATTRIBUTE_RETAIN);
+
+  /* Creating the `blabla` variable. */
+  gcc_jit_type *const_int = gcc_jit_type_get_const (int_type);
+  gcc_jit_lvalue *glob = gcc_jit_context_new_global (ctxt,
+						     NULL,
+						     GCC_JIT_GLOBAL_INTERNAL,
+						     const_int,
+						     "blabla");
+  gcc_jit_lvalue_add_attribute(glob, GCC_JIT_VARIABLE_ATTRIBUTE_RETAIN);
+}
+
+/* { dg-final { jit-verify-output-file-was-created "" } } */
+
+/* We check that the retained attribute worked as expected and added the `R` in the section info. */
+/* { dg-final { jit-verify-assembler-output ".section\\s+.text.not_removed,\"axR\" } } */
+/* { dg-final { jit-verify-assembler-output ".section\\s+.rodata.blabla,\"aR\" } } */


### PR DESCRIPTION
Needed because rustc makes the difference between `used(compiler)` and `used(linker)`.