### PR TITLE
Correctly handle `packed` attribute on a type fields

### DIFF
--- a/gcc/jit/jit-playback.cc
+++ b/gcc/jit/jit-playback.cc
@@ -546,7 +546,10 @@ playback::compound_type::set_fields (const auto_vec<playback::field *> *fields)
 	  DECL_BIT_FIELD (x) = 1;
 	}
 
-      fieldlist = chainon (x, fieldlist);
+        if (TYPE_PACKED(t) && (DECL_BIT_FIELD (x)
+	  || TYPE_ALIGN (TREE_TYPE (x)) > BITS_PER_UNIT))
+	  DECL_PACKED (x) = 1;
+	fieldlist = chainon (x, fieldlist);
     }
   fieldlist = nreverse (fieldlist);
   TYPE_FIELDS (t) = fieldlist;


### PR DESCRIPTION
Fixes bug introduced in https://github.com/rust-lang/gcc/pull/93.